### PR TITLE
udpping: add ' measure-it.net' string to payload

### DIFF
--- a/src/libclient/measurement/udpping/udpping_linux.cpp
+++ b/src/libclient/measurement/udpping/udpping_linux.cpp
@@ -50,6 +50,12 @@ namespace
         {
             payload[i] = chars[qrand() % strlen(chars)];
         }
+
+        if (size > 15)
+        {
+            // ignore terminating null character
+            strncpy(&payload[size - 15], " measure-it.net", 15);
+        }
     }
 }
 

--- a/src/libclient/measurement/udpping/udpping_win.cpp
+++ b/src/libclient/measurement/udpping/udpping_win.cpp
@@ -165,6 +165,12 @@ namespace
         {
             payload[i] = chars[qrand() % strlen(chars)];
         }
+
+        if (size > 15)
+        {
+            // ignore terminating null character
+            strncpy(&payload[size - 15], " measure-it.net", 15);
+        }
     }
 }
 


### PR DESCRIPTION
If the size of the payload is large enough, add ' measure-it.net' to the
end of it.
