### PR TITLE
check whether interface list is empty

### DIFF
--- a/src/libclient/networkhelper.cpp
+++ b/src/libclient/networkhelper.cpp
@@ -97,7 +97,10 @@ QHostAddress NetworkHelper::localIpAddress()
         }
     }
 
-    hostIp = interfaceAddressList.first();
+    if (!interfaceAddressList.empty())
+    {
+        hostIp = interfaceAddressList.first();
+    }
     //qDebug() << "Hope" << hostIp << "is a local ip";
 
 #endif


### PR DESCRIPTION
Check the interface list before calling first(), otherwise the app will
crash.
