### PR TITLE
asynchronous ntp (fixes #113)

### DIFF
--- a/src/libclient/client.cpp
+++ b/src/libclient/client.cpp
@@ -325,6 +325,18 @@ bool Client::init()
     qRegisterMetaType<TestDefinitionPtr>();
     qRegisterMetaType<ResultPtr>();
 
+    // Get network time from ntp server
+    QHostInfo hostInfo = QHostInfo::fromName("ptbtime1.ptb.de");
+    if (!hostInfo.addresses().isEmpty())
+    {
+        QHostAddress ntpServer = hostInfo.addresses().first();
+        ntp->sync(ntpServer);
+    }
+    else
+    {
+        LOG_WARNING("could not resolve ntp server");
+    }
+
     d->setupUnixSignalHandlers();
     d->settings.init();
 
@@ -342,18 +354,6 @@ bool Client::init()
     if (!d->settings.isPassive())
     {
         d->taskController.init(&d->networkManager, &d->scheduler, &d->settings);
-    }
-
-    // Get network time from ntp server
-    QHostInfo hostInfo = QHostInfo::fromName("ptbtime1.ptb.de");
-    if (!hostInfo.addresses().isEmpty())
-    {
-        QHostAddress ntpServer = hostInfo.addresses().first();
-        ntp->sync(ntpServer);
-    }
-    else
-    {
-        LOG_WARNING("could not resolve ntp server");
     }
 
     return true;

--- a/src/libclient/timing/ntp.cpp
+++ b/src/libclient/timing/ntp.cpp
@@ -9,6 +9,7 @@ Ntp::Ntp(QObject *parent)
     : QObject(parent)
 {
     m_socket = new QUdpSocket(this);
+    connect(m_socket, SIGNAL(readyRead()), this, SLOT(readResponse()));
 }
 
 Ntp::~Ntp()
@@ -29,17 +30,6 @@ bool Ntp::sync(QHostAddress &host)
     if (m_socket->writeDatagram((char *)&packet, sizeof(packet), host, 123) < 0)
     {
         emit error("writeDatagram");
-        return false;
-    }
-
-    if (m_socket->waitForReadyRead())
-    {
-        readResponse();
-    }
-    else
-    {
-        LOG_WARNING("no response from ntp server");
-        emit error("no response from ntp server");
         return false;
     }
 

--- a/src/libclient/timing/ntp.h
+++ b/src/libclient/timing/ntp.h
@@ -69,7 +69,6 @@ public:
     QDateTime localTime() const;
     QDateTime networkTime() const;
     quint64 offset() const;
-    void readResponse();
 
 signals:
     void error(QString message);
@@ -78,6 +77,9 @@ private:
     QUdpSocket *m_socket;
     QDateTime m_localTime;
     QDateTime m_networkTime;
+
+private slots:
+    void readResponse();
 };
 
 #endif // NTP_H


### PR DESCRIPTION
Use async ntp to prevent the app from blocking when the ntp server
cannot be reached.
