### PR TITLE
udpping: fix UDP response handling for Windows

### DIFF
--- a/src/libclient/measurement/udpping/udpping.h
+++ b/src/libclient/measurement/udpping/udpping.h
@@ -69,6 +69,7 @@ struct PingProbe
     quint8 icmpType;
     quint8 icmpCode;
     QByteArray hash;
+    bool marked;
 
     bool operator==(const PingProbe &p) const
     {


### PR DESCRIPTION
ICMP responses takes precedence over UDP responses as the former can be
matched against a specific UDP request packet by comparing the payload
hashes.

Remaining UDP responses are assigned a UDP request according to their
order, i.e. 1st request -> 1st response, 2nd request -> 2nd response,
and so on.
