### PR TITLE
Immediate timing for reports and Timer class for controllers

### DIFF
--- a/src/libclient/client.h
+++ b/src/libclient/client.h
@@ -84,7 +84,7 @@ public:
      * Source: http://semver.org
      */
     static const quint32 versionMajor = 2;
-    static const quint32 versionMinor = 1;
+    static const quint32 versionMinor = 2;
     static const quint32 versionPatch = 0;
 
 public slots:

--- a/src/libclient/libclient.pro
+++ b/src/libclient/libclient.pro
@@ -172,7 +172,8 @@ SOURCES +=  \
     localinformation.cpp \
     measurement/wifilookup/wifilookup_definition.cpp \
     measurement/wifilookup/wifilookup_plugin.cpp \
-    storage/storage.cpp
+    storage/storage.cpp \
+    timing/timer.cpp
 
 HEADERS += \
     export.h \
@@ -269,7 +270,8 @@ HEADERS += \
     measurement/wifilookup/wifilookup_definition.h \
     measurement/wifilookup/wifilookup_plugin.h \
     ident.h \
-    storage/storage.h
+    storage/storage.h \
+    timing/timer.h
 
 OTHER_FILES += \
     libclient.pri

--- a/src/libclient/timing/timer.cpp
+++ b/src/libclient/timing/timer.cpp
@@ -1,0 +1,92 @@
+#include "timer.h"
+#include "../log/logger.h"
+
+#include <QTimer>
+
+LOGGER(Timer)
+
+class Timer::Private : public QObject
+{
+    Q_OBJECT
+
+public:
+    Private(Timer *q)
+    : q(q)
+    {
+        qtimer.setSingleShot(true);
+        qtimer.setTimerType(Qt::PreciseTimer);
+        connect(&qtimer, SIGNAL(timeout()), q, SLOT(start()));
+        connect(&qtimer, SIGNAL(timeout()), q, SIGNAL(timeout()));
+    }
+
+    Timer *q;
+    QTimer qtimer;
+    TimingPtr timing;
+};
+
+Timer::Timer(QObject *parent)
+: QObject(parent)
+, d(new Private(this))
+{
+}
+
+Timer::Timer(const TimingPtr &timing, QObject *parent)
+: QObject(parent)
+, d(new Private(this))
+{
+    setTiming(timing);
+}
+
+Timer::~Timer()
+{
+    delete d;
+}
+
+void Timer::setTimerType(Qt::TimerType atype)
+{
+    d->qtimer.setTimerType(atype);
+}
+
+Qt::TimerType Timer::timerType() const
+{
+    return d->qtimer.timerType();
+}
+
+void Timer::setTiming(const TimingPtr &timing)
+{
+    if (timing->type() == "immediate")
+    {
+        LOG_ERROR(QString("Immediate timing not allowed for timer"));
+        return;
+    }
+
+    if (d->timing != timing)
+    {
+        d->timing = timing;
+        emit timingChanged();
+    }
+}
+
+TimingPtr Timer::timing() const
+{
+    return d->timing;
+}
+
+void Timer::start()
+{
+    if (d->timing)
+    {
+        d->qtimer.start(d->timing->timeLeft());
+    }
+    else
+    {
+        LOG_ERROR(QString("Could not start timer, timing not set"));
+    }
+}
+
+void Timer::stop()
+{
+    d->qtimer.stop();
+}
+
+#include "timer.moc"

--- a/src/libclient/timing/timer.h
+++ b/src/libclient/timing/timer.h
@@ -1,0 +1,35 @@
+#ifndef TIMER_H
+#define TIMER_H
+
+#include "timing.h"
+
+#include <QObject>
+
+class Timer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit Timer(QObject *parent = 0);
+    explicit Timer(const TimingPtr &timing, QObject *parent = 0);
+    ~Timer();
+
+    void setTimerType(Qt::TimerType atype);
+    Qt::TimerType timerType() const;
+
+    void setTiming(const TimingPtr &timing);
+    TimingPtr timing() const;
+
+signals:
+    void timeout();
+    void timingChanged();
+
+public slots:
+    void start();
+    void stop();
+
+protected:
+    class Private;
+    Private *d;
+};
+
+#endif // TIMER_H

--- a/src/libclient/timing/timer.h
+++ b/src/libclient/timing/timer.h
@@ -5,7 +5,7 @@
 
 #include <QObject>
 
-class Timer : public QObject
+class CLIENT_API Timer : public QObject
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
This makes it possible to get the results of a measurement immediately after they are available.

The controllers now use an own timer, this takes the random spread into account. These timings are now relative to their starting point and not to the start of the controller.