### PR TITLE
Emergency fix for a system breaking bug

### DIFF
--- a/src/libclient/settings.cpp
+++ b/src/libclient/settings.cpp
@@ -141,6 +141,12 @@ QString Settings::userId() const
 
 QString Settings::hashedUserId() const
 {
+    // this is an emergency fix, we can remove this later
+    if (!d->settings.contains("hashed-user-id"))
+    {
+        d->settings.setValue("hashed-user-id", userIdToHash(userId()));
+    }
+
     return d->settings.value("hashed-user-id").toString();
 }
 

--- a/src/libclient/settings.cpp
+++ b/src/libclient/settings.cpp
@@ -24,7 +24,7 @@ void Settings::Private::sync()
 {
     settings.setValue("config", config.toVariant());
 
-     // remove password before sync so it is not written into storage
+    // remove password before sync so it is not written into storage
     QVariant tmpPassword = settings.value("password");
     settings.remove("password");
     settings.sync();
@@ -69,6 +69,15 @@ Settings::StorageType Settings::init()
     }
 
     LOG_INFO(QString("Device ID: %1").arg(deviceId()));
+
+    // this is an emergency fix, we can remove this later
+    if (!userId().isEmpty())
+    {
+        if (!d->settings.contains("hashed-user-id"))
+        {
+            d->settings.setValue("hashed-user-id", userIdToHash(userId()));
+        }
+    }
 
     // Create new settings
     if (newSettings)
@@ -141,12 +150,6 @@ QString Settings::userId() const
 
 QString Settings::hashedUserId() const
 {
-    // this is an emergency fix, we can remove this later
-    if (!d->settings.contains("hashed-user-id"))
-    {
-        d->settings.setValue("hashed-user-id", userIdToHash(userId()));
-    }
-
     return d->settings.value("hashed-user-id").toString();
 }
 


### PR DESCRIPTION
We did not consider already logged in probes when changing how the
hashed userId is saved. They don't have the value in their configs yet.
With this change they generate it if it does not exist.

I am not sure where to put this, I guess the Settings init function is a good location because then is is only checked once.