### PR TITLE
postinst: check for service and systemctl

### DIFF
--- a/debian/glimpse-console.postinst
+++ b/debian/glimpse-console.postinst
@@ -12,8 +12,14 @@ set -e
 case "$1" in
     configure)
     adduser --system --group --quiet $USER_NAME || true
-	service $SERVICE_NAME start || true
-	systemctl start $SERVICE_NAME || true
+
+    if which service &>/dev/null; then
+        service $SERVICE_NAME start || true
+    fi
+
+    if which systemctl &>/dev/null; then
+        systemctl start $SERVICE_NAME || true
+    fi
     ;;
 esac
 


### PR DESCRIPTION
To avoid getting output such as "/var/lib/dpkg/info/glimpse-
console.postinst: 16: /var/lib/dpkg/info/glimpse-console.postinst:
systemctl: not found", we check whether both binaries exist.