### PR TITLE
postinst: change home directory

### DIFF
--- a/debian/glimpse-console.postinst
+++ b/debian/glimpse-console.postinst
@@ -11,7 +11,7 @@ set -e
 
 case "$1" in
     configure)
-        adduser --system --group --quiet $USER_NAME || true
+        adduser --system --group --quiet --home /var/lib/glimpse $USER_NAME || true
 
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME start || true


### PR DESCRIPTION
Move the home directory to /var/lib/glimpse as /home should be used for
real users only.