### PR TITLE
ping: modify result fields (resolves #303)

### DIFF
--- a/src/libclient/measurement/ping/ping.h
+++ b/src/libclient/measurement/ping/ping.h
@@ -145,6 +145,8 @@ private:
     Status currentStatus;
     QVector<PingProbe> m_pingProbes;
     QList<float> pingTime;
+    quint32 m_pingsSent;
+    quint32 m_pingsReceived;
 
     pcap_if_t *m_device;
     pcap_t *m_capture;


### PR DESCRIPTION
Timeouts are now ignored in the stats. Also, the fields "round_trip_loss", "round_trip_sent" and "round_trip_received" have been added.