### PR TITLE
build: fix breakpad on Android

### DIFF
--- a/3rdparty/breakpad.pro
+++ b/3rdparty/breakpad.pro
@@ -25,7 +25,7 @@ win32 {
 android {
     CONFIG += breakpad-builtin
 
-    INCLUDEPATH += $$BREAKPAD_PATH/src/common/android/include
+    QMAKE_CXXFLAGS += -I$$BREAKPAD_PATH/src/common/android/include
 
     SOURCES += $$BREAKPAD_PATH/src/client/linux/crash_generation/crash_generation_client.cc \
                $$BREAKPAD_PATH/src/client/linux/handler/exception_handler.cc \


### PR DESCRIPTION
INCLUDEPATH seems to be buggy in Qt5/Android.  It uses `-isystem <path>`
instead of `-I <path>` which might explain the failed build.  Working
around this by using `QMAKE_CXXFLAGS` works fine.