### PR TITLE
Use UTC within GLIMPSE 

### DIFF
--- a/src/libclient/controller/ntpcontroller.cpp
+++ b/src/libclient/controller/ntpcontroller.cpp
@@ -178,7 +178,7 @@ QDateTime NtpController::networkTime() const
 
 QDateTime NtpController::currentDateTime() const
 {
-    return QDateTime::currentDateTime().addSecs(this->offset());
+    return QDateTime::currentDateTimeUtc().addSecs(this->offset());
 }
 
 quint64 NtpController::offset() const

--- a/src/libclient/timing/calendartiming.cpp
+++ b/src/libclient/timing/calendartiming.cpp
@@ -183,12 +183,12 @@ QDateTime CalendarTiming::nextRun(const QDateTime &tzero) const
                                 // if the next run date is not today we can take the first items
                                 // as this is the earliest allowed time on that day
                                 nextRunTime = QTime(*d->hours.constBegin(), *d->minutes.constBegin(), *d->seconds.constBegin());
-                                nextRun = QDateTime(nextRunDate, nextRunTime);
+                                nextRun = QDateTime(nextRunDate, nextRunTime, Qt::UTC);
                                 found = true;
                             }
                             else if ((nextRunTime = d->findTime(time)).isValid())
                             {
-                                nextRun = QDateTime(nextRunDate, nextRunTime);
+                                nextRun = QDateTime(nextRunDate, nextRunTime, Qt::UTC);
 
                                 // check if the calculated next run was already executed
                                 if (!m_lastExecution.isValid() || m_lastExecution.secsTo(nextRun) > 1)

--- a/src/libclient/timing/onofftiming.cpp
+++ b/src/libclient/timing/onofftiming.cpp
@@ -32,7 +32,7 @@ bool OnOffTiming::reset()
 QDateTime OnOffTiming::nextRun(const QDateTime &tzero) const
 {
     Q_UNUSED(tzero)
-    return d->dateTime.addSecs(Client::instance()->ntpController()->offset());
+    return d->dateTime;
 }
 
 bool OnOffTiming::isValid() const

--- a/src/tests/libclient/timing/calendartiming/tst_calendartiming.cpp
+++ b/src/tests/libclient/timing/calendartiming/tst_calendartiming.cpp
@@ -2,6 +2,8 @@
 
 #include <timing/calendartiming.h>
 
+#include <controller/ntpcontroller.h>
+
 class TestCalendarTiming : public QObject
 {
     Q_OBJECT
@@ -9,12 +11,17 @@ class TestCalendarTiming : public QObject
 private slots:
     void nextRuns()
     {
-        QTime time = QTime::currentTime();
+
+        NtpController ntp;
+        ntp.init();
+
+        QDateTime now = ntp.currentDateTime();
+
+        QTime time = now.time();
         time = QTime(time.hour(), time.minute(), time.second()); // to remove milliseconds
-        QDateTime now = QDateTime::currentDateTime();
         now.setTime(time);
 
-        QDateTime start = QDateTime::currentDateTime();
+        QDateTime start = ntp.currentDateTime();
         QDateTime end;
         QList<int> months = CalendarTiming::AllMonths;
         QList<int> daysOfWeek =  CalendarTiming::AllDaysOfWeek;
@@ -69,12 +76,12 @@ private slots:
         //test if timing at 6am until 2am is wrong
         CalendarTiming sixTiming(start.addDays(-1), end,  months, daysOfWeek, daysOfMonth, QList<int>()<<2<<6, QList<int>()<<0, QList<int>()<<0);
         qDebug("nextRun today at 6");
-        QCOMPARE(sixTiming.nextRun(QDateTime(now.date(), QTime(5,0,0))), QDateTime(now.date(), QTime(6,0,0)));
+        QCOMPARE(sixTiming.nextRun(QDateTime(now.date(), QTime(5,0,0))), QDateTime(now.date(), QTime(6,0,0), Qt::UTC));
 
         //test if timing at 2am until 6am is wrong
         CalendarTiming twoTiming(start.addDays(-1), end,  months, daysOfWeek, daysOfMonth, QList<int>()<<2<<6, QList<int>()<<0, QList<int>()<<0);
         qDebug("nextRun today at 2");
-        QCOMPARE(twoTiming.nextRun(QDateTime(now.date(), QTime(1,0,0))), QDateTime(now.date(), QTime(2,0,0)));
+        QCOMPARE(twoTiming.nextRun(QDateTime(now.date(), QTime(1,0,0))), QDateTime(now.date(), QTime(2,0,0), Qt::UTC));
 
         // start next month because day already passed this month
         CalendarTiming nextMonthTiming(QDateTime(), end, months, daysOfWeek, QList<int>()<<1, hours, minutes, seconds);
@@ -97,7 +104,7 @@ private slots:
         // start next year because day already passed this year
         CalendarTiming yearTiming(start, end,  QList<int>()<<1, daysOfWeek, QList<int>()<<1, hours, minutes, seconds);
         qDebug("nextRun on January 1st");
-        QCOMPARE(yearTiming.nextRun(QDateTime(QDate(now.date().year(), now.date().month(), 2))), QDateTime(QDate(now.date().year()+1, 1, 1), QTime(0,0,0)));
+        QCOMPARE(yearTiming.nextRun(QDateTime(QDate(now.date().year(), now.date().month(), 2))), QDateTime(QDate(now.date().year()+1, 1, 1), QTime(0,0,0), Qt::UTC));
     }
 };
 

--- a/src/tests/libclient/timing/onofftiming/tst_onofftiming.cpp
+++ b/src/tests/libclient/timing/onofftiming/tst_onofftiming.cpp
@@ -1,6 +1,7 @@
 #include <QtTest>
 
 #include <timing/onofftiming.h>
+#include <controller/ntpcontroller.h>
 
 class TestOnOffTiming : public QObject
 {
@@ -9,7 +10,10 @@ class TestOnOffTiming : public QObject
 private slots:
     void nextRuns()
     {
-        QDateTime start = QDateTime::currentDateTime();
+        NtpController ntp;
+        ntp.init();
+
+        QDateTime start = ntp.currentDateTime();
         OnOffTiming timing(start);
 
         QCOMPARE(timing.type(), QLatin1String("onoff"));

--- a/src/tests/libclient/timing/periodictiming/tst_periodictiming.cpp
+++ b/src/tests/libclient/timing/periodictiming/tst_periodictiming.cpp
@@ -1,6 +1,7 @@
 #include <QtTest>
 
 #include <timing/periodictiming.h>
+#include <controller/ntpcontroller.h>
 
 class TestPeriodicTiming : public QObject
 {
@@ -16,7 +17,10 @@ private slots:
 
     void nextRuns()
     {
-        QDateTime now = QDateTime::currentDateTime();
+        NtpController ntp;
+        ntp.init();
+
+        QDateTime now = ntp.currentDateTime();
 
         // milliseconds, minutes and hours with infinite timing
         PeriodicTiming tenMs(10, QDateTime(), QDateTime(), 0);


### PR DESCRIPTION
This was a bug, we should use UTC and the NTP controller everywhere. The implementation of nextRun in onofftiming was wrong.