### PR TITLE
Fix hangup in httpdownload

### DIFF
--- a/src/libclient/client.h
+++ b/src/libclient/client.h
@@ -95,7 +95,7 @@ public:
      */
     static const quint32 versionMajor = 2;
     static const quint32 versionMinor = 5;
-    static const quint32 versionPatch = 1;
+    static const quint32 versionPatch = 2;
 
 public slots:
     bool init();

--- a/src/libclient/measurement/http/httpdownload.cpp
+++ b/src/libclient/measurement/http/httpdownload.cpp
@@ -404,7 +404,7 @@ bool HTTPDownload::startThreads(const QHostInfo &server)
     {
         //create a worker thread that starts an actual download
         QThread *workerThread = new QThread();
-        DownloadThread *worker = new DownloadThread(requestUrl, server, definition->targetTime, definition->avoidCaches);
+        DownloadThread *worker = new DownloadThread(requestUrl, server, definition->targetTime, definition->avoidCaches, workerThread);
 
         //store the references to the threads/workers
         workers.append(worker);


### PR DESCRIPTION
This unresolves #301, so we have a warning in http download that we can't move the worker to a thread because it has a parent, but apparently removing the parent leads to a hangup in the httpdownload.