### PR TITLE
fix traffic budget manager

### DIFF
--- a/src/libclient/trafficbudgetmanager.cpp
+++ b/src/libclient/trafficbudgetmanager.cpp
@@ -114,6 +114,7 @@ bool TrafficBudgetManager::addUsedTraffic(quint32 traffic)
         if (d->availableMobileTraffic >= traffic)
         {
             d->usedMobileTraffic += traffic;
+            d->availableMobileTraffic -= traffic;
             saveTraffic();
             return true;
         }
@@ -123,6 +124,7 @@ bool TrafficBudgetManager::addUsedTraffic(quint32 traffic)
         if (d->availableTraffic >= traffic)
         {
             d->usedTraffic += traffic;
+            d->availableTraffic -= traffic;
             saveTraffic();
             return true;
         }


### PR DESCRIPTION
The traffic budget manager never actually set
'available{,Mobile}Traffic' in the settings and hence never used the
traffic budget. This can now be considered fixed.